### PR TITLE
Supporters: Corrects heading text, big Change Mcr: Adds Boaz Trust

### DIFF
--- a/src/pages/manchester/bigchangemcr/partners/index.hbs
+++ b/src/pages/manchester/bigchangemcr/partners/index.hbs
@@ -50,6 +50,13 @@ page: bigchangepartners
           </a>
         </article>
         <article>
+          <h3 class="h3">Boaz Trust</h3>
+          <p>The Boaz Trust is a Christian charity serving destitute asylum seekers and refugees in Greater Manchester.</p>
+          <a class="btn btn--brand-d btn--full" href="/find-help/organisation/?organisation=boaz-trust">
+            <span class="btn__text">More information about Boaz Trust</span>
+          </a>
+        </article>
+        <article>
           <h3 class="h3">Booth Centre</h3>
           <p>The Booth Centre is a day centre offering activities, advice and support.</p>
           <a class="btn btn--brand-d btn--full" href="/find-help/organisation/?organisation=booth-centre">

--- a/src/partials/bournemouth/supporters.hbs
+++ b/src/partials/bournemouth/supporters.hbs
@@ -1,4 +1,4 @@
-<h2 class="h2">Funded and supported by&hellip;</h2>
+<h2 class="h2">Supported by&hellip;</h2>
 <ul class="partners__list">
   <li class="partners__logo partners__logo--big-lottery-fund"><a href="https://www.biglotteryfund.org.uk/">{{> icon name="big-lottery-fund"}}</a></li>
 </ul>

--- a/src/partials/no-location/supporters.hbs
+++ b/src/partials/no-location/supporters.hbs
@@ -1,4 +1,4 @@
-<h2 class="h2">Funded and supported by&hellip;</h2>
+<h2 class="h2">Supported by&hellip;</h2>
 <ul class="partners__list">
   <li class="partners__logo partners__logo--big-lottery-fund"><a href="https://www.biglotteryfund.org.uk/">{{> icon name="big-lottery-fund"}}</a></li>
 </ul>

--- a/src/partials/portsmouth/supporters.hbs
+++ b/src/partials/portsmouth/supporters.hbs
@@ -1,4 +1,4 @@
-<h2 class="h2">Funded and supported by&hellip;</h2>
+<h2 class="h2">Supported by&hellip;</h2>
 <ul class="partners__list">
   <li class="partners__logo partners__logo--big-lottery-fund"><a href="https://www.biglotteryfund.org.uk/">{{> icon name="big-lottery-fund"}}</a></li>
 </ul>


### PR DESCRIPTION
Fix for heading text after clarification on apparent ‘inconsistency’ - it is intentional.

See: https://trello.com/c/Txj3KAOh/1572-web-add-human-appeal-and-big-lottery-logos-to-footer

Adds Boaz trust to list of partners on Big change Mcr page

See: https://trello.com/c/2SQtjMIi/1566-web-add-boaz-trust-to-list-of-big-change-partners