### PR TITLE
full width overlay - btn position fix on IE11, fix for position of partners logo's on FF

### DIFF
--- a/src/scss/partials/_full-width-overlay.scss
+++ b/src/scss/partials/_full-width-overlay.scss
@@ -58,7 +58,6 @@
   margin-right: 10px;
 
   @include mq($from: m) {
-    // margin-left: -30%;
     left: 20%;
     bottom: 20px;
     width: 60%;

--- a/src/scss/partials/_full-width-overlay.scss
+++ b/src/scss/partials/_full-width-overlay.scss
@@ -58,7 +58,8 @@
   margin-right: 10px;
 
   @include mq($from: m) {
-    margin-left: -30%;
+    // margin-left: -30%;
+    left: 20%;
     bottom: 20px;
     width: 60%;
     position: absolute;

--- a/src/scss/partials/_partners.scss
+++ b/src/scss/partials/_partners.scss
@@ -41,7 +41,7 @@
       svg {
         position: absolute;
         top: 50%;
-        transform: translateY(-50%);
+        // transform: translateY(-50%);
         left: 0;
       }
     }
@@ -88,6 +88,7 @@
         svg {
           height: 38px;
           width: 195px;
+          margin-top: -19px;
         }
       }
     }
@@ -99,6 +100,7 @@
         svg {
           height: 38px;
           width: 90px;
+          margin-top: -19px;
         }
       }
     }
@@ -134,6 +136,7 @@
         svg {
           height: 96px;
           width: 120px;
+          margin-top: -48px;
         }
       }
     }

--- a/src/scss/partials/_partners.scss
+++ b/src/scss/partials/_partners.scss
@@ -51,7 +51,8 @@
     }
 
     &--coalition-of-relief {
-      width: 57px
+      width: 57px;
+      
       a {
         background-image: url(/assets/img/coalition-of-relief.png);
       }

--- a/src/scss/partials/_partners.scss
+++ b/src/scss/partials/_partners.scss
@@ -19,8 +19,6 @@
     position: relative;
     overflow: hidden;
     margin: 0 10px;
-    // padding-top: 10px;
-    // line-height: 7;
 
     a {
       display: block;
@@ -41,7 +39,6 @@
       svg {
         position: absolute;
         top: 50%;
-        // transform: translateY(-50%);
         left: 0;
       }
     }


### PR DESCRIPTION
Left old style in, but commented. This works fine, but if the button width were to change for example, the left value would need to change correspondingly. Could be improved/more flexible, but not sure of depth of browser support needed, so just making it look ok to get it out!