### PR TITLE
Use NODE_ENV instead of a custom env.js file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ Run these tasks in your command line Terminal:
 
 ### Environments
 
-There are three API environments: CI, UAT and LIVE. You can alter the API your local instance is running from by editing [/blob/develop/src/js/env.js](/blob/develop/src/js/env.js):
+There are four possible environments: local, CI (Continuous Integration), UAT (User Acceptance Testing) and LIVE.
+You can alter the API your local instance is running from by changing the `NODE_ENV` variable to one of four numbers:
 
-* 0: locally running API instance
+* 0: local
 * 1: CI
 * 2: UAT
 * 3: LIVE

--- a/deploy-website.sh
+++ b/deploy-website.sh
@@ -4,26 +4,26 @@
 set -e
 
 # Set a default API environment for other branches/pull requests
-APIENVIRONMENT=1
+NODE_ENV=1
 
 # Define variables depending on the branch
 if [[ $TRAVIS_BRANCH == 'release' ]]
   then
     AZURE_WEBSITE=$PROD_AZURE_WEBSITE
     APP_INSIGHTS_KEY=$PROD_APP_INSIGHTS_KEY
-    APIENVIRONMENT=3
+    NODE_ENV=3
 fi
 if [[ $TRAVIS_BRANCH == 'uat' ]]
   then
     AZURE_WEBSITE=$UAT_AZURE_WEBSITE
     APP_INSIGHTS_KEY=$UAT_APP_INSIGHTS_KEY
-    APIENVIRONMENT=2
+    NODE_ENV=2
 fi
 if [[ $TRAVIS_BRANCH == 'develop' ]]
   then
     AZURE_WEBSITE=$DEV_AZURE_WEBSITE
     APP_INSIGHTS_KEY=''
-    APIENVIRONMENT=1
+    NODE_ENV=1
 fi
 
 # block robots if not live
@@ -46,17 +46,6 @@ THE_COMMIT=`git rev-parse HEAD`
 # Set git details
 git config --global user.email "enquiry@streetsupport.net"
 git config --global user.name "Travis CI"
-
-# Set environment
-cd src/js
-rm env.js
-cat > env.js << EOF
-module.exports = $APIENVIRONMENT
-EOF
-
-echo "env.js file rewritten to:"
-cat env.js
-cd ../../
 
 # Create version.txt
 cd src/files

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -3,11 +3,17 @@ var dev = 'https://ssn-api-dev.azurewebsites.net'
 var staging = 'https://ssn-api-uat.azurewebsites.net'
 var live = 'https://ssn-api-prod.azurewebsites.net'
 
-var env = require('./env')
+// Default the env to '1' for CI.
+// This can be overwritten by running gulp with NODE_ENV=X gulp.
+var env = process.env.NODE_ENV || 1
 
 var envs = [local, dev, staging, live]
 
 var domainRoot = envs[env]
+
+if (!domainRoot) {
+  throw new Error(`Environment ${env} not found`)
+}
 
 var p = function (url) {
   return domainRoot + url

--- a/src/js/env.js
+++ b/src/js/env.js
@@ -1,1 +1,0 @@
-module.exports = 1


### PR DESCRIPTION
It's the standard in the node community to use NODE_ENV as the
environment variable. In addition, it's not recommended to have a file
that can change that we don't want to change checked into the repo. If
that number is inadvertently changed it could cause issues, although
there may be safety checks around it that I'm unaware of.

Therefore, remove the env.js file and replace it with NODE_ENV. This
changed the deployment script, and the api.js file. Default to "1" as
the CI environment.

Also update the README to explain the environments a little bit more, as
on first read not everyone may be familiar with "CI" and "UAT" as terms.
And include "local" in the environment possibilities.