### PR TITLE
Added default location value to fix `undefined` issue on modal

### DIFF
--- a/src/js/location/locationSelector.js
+++ b/src/js/location/locationSelector.js
@@ -129,7 +129,7 @@ const _determineLocationRetrievalMethod = () => {
 }
 
 const getSelectedLocationId = () => {
-  const saved = cookies.get(cookies.keys.location)
+  const saved = cookies.get(cookies.keys.location) || 'elsewhere'
   if (cookies.get(cookies.keys.location) !== undefined && saved.length > 0) {
     return supportedCities.get(saved).id
   }

--- a/src/js/navigation/nav.js
+++ b/src/js/navigation/nav.js
@@ -11,6 +11,7 @@ const activeClass = 'is-active'
 const el = document.querySelectorAll('.js-nav-container, .js-nav-push, .js-nav-overlay, html, body')
 
 const hideForCity = (cityId) => {
+  if (!cityId) return
   var citySpecificElements = document.querySelectorAll('[data-city]')
   for (let i = 0; i < citySpecificElements.length; i++) {
     let citiesRequired = citySpecificElements[i].getAttribute('data-city')

--- a/src/js/navigation/nav.js
+++ b/src/js/navigation/nav.js
@@ -11,7 +11,6 @@ const activeClass = 'is-active'
 const el = document.querySelectorAll('.js-nav-container, .js-nav-push, .js-nav-overlay, html, body')
 
 const hideForCity = (cityId) => {
-  if (!cityId) return
   var citySpecificElements = document.querySelectorAll('[data-city]')
   for (let i = 0; i < citySpecificElements.length; i++) {
     let citiesRequired = citySpecificElements[i].getAttribute('data-city')


### PR DESCRIPTION
When visiting https://streetsupport.net/ for the first time (Chrome/Safari) there is a console error `Uncaught TypeError: Cannot read property 'name' of undefined` which I have traced back to an undefined param on `hideForCity()` (L13 of nav.js). 

It looks as though `cookies.get(cookies.keys.location)` is undefined in the `getSelectedLocationId()` method so I have set this to return `'elsewhere'` by default. 