### PR TITLE
Add favicon to head template

### DIFF
--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -13,6 +13,7 @@
     <meta property="og:image" content="{{image}}" />
 
     <link rel="stylesheet" href="{{site.url}}assets/css/site.css?v={{cachebusting.date}}" />
+    <link rel="shortcut icon" href="{{site.url}}favicon.ico" type="image/x-icon" />
 
     {{> head/google-tag-manager }}
     {{> head/web-fonts }}


### PR DESCRIPTION
Some browsers automatically find and cache this so to verify it works, change the href that is pointed to e.g. `{{site.url}}assets/img/jez.jpg`