### PR TITLE
sort needs by new neededDate property

### DIFF
--- a/src/js/models/give-help/requests/listing.js
+++ b/src/js/models/give-help/requests/listing.js
@@ -6,12 +6,12 @@ const activeClass = 'is-active'
 const initList = () => {
    // List.js
   const options = {
-    valueNames: [ 'type', 'serviceProviderName', 'creationDate', 'description', 'keywords', 'distanceAwayInMetres' ],
+    valueNames: [ 'type', 'serviceProviderName', 'creationDate', 'neededDate', 'description', 'keywords', 'distanceAwayInMetres' ],
     plugins: []
   }
 
   const theList = new List('js-card-search', options)
-  theList.sort('creationDate', { order: 'desc' })
+  theList.sort('neededDate', { order: 'desc' })
 
   return theList
 }
@@ -84,7 +84,7 @@ const initSorting = (theList) => {
     b.addEventListener('click', (event) => {
       let sortFields = []
       sortFields['organisation'] = 'serviceProviderName'
-      sortFields['date'] = 'creationDate'
+      sortFields['date'] = 'neededDate'
       sortFields['distance'] = 'distanceAwayInMetres'
 
       let selectedSort = event.target.getAttribute('data-sort')

--- a/src/js/models/give-help/requests/needs.js
+++ b/src/js/models/give-help/requests/needs.js
@@ -5,6 +5,7 @@ const getLocation = require('../../../location/get-location')
 
 const formatDate = (n) => {
   n.formattedCreationDate = moment(n.creationDate).fromNow()
+  n.formattedNeededDate = moment(n.neededDate).fromNow()
 }
 
 const setPostcodeAsLocation = (n) => {
@@ -26,6 +27,7 @@ export const formatNeeds = (needs, position) => {
     : setDistanceAsLocation
   needs
     .forEach((n) => {
+      n.neededDate = n.neededDate || n.creationDate
       formatDate(n)
       locationFormatter(n, position)
       n.detailsUrl = `request/?id=${n.id}`

--- a/src/pages/give-help/help/index.hbs
+++ b/src/pages/give-help/help/index.hbs
@@ -109,8 +109,9 @@ page: giveitems
         \{{#donationAmountInPounds}}<p class="requests-listing__amount">£\{{{donationAmountInPounds}}}</p>\{{/donationAmountInPounds}}
         <div class="requests-listing__info">
           <h3 class="requests-listing__description description">\{{{description}}}</h3>
-          <p class="requests-listing__date formattedCreationDate">Posted: <time datetime={{{formattedCreationDate}}}>\{{{formattedCreationDate}}}</time></p>
+          <p class="requests-listing__date formattedNeededDate">Posted: <time datetime={{{formattedNeededDate}}}>\{{{formattedNeededDate}}}</time></p>
           <p class="hide-screen creationDate">\{{creationDate}}</p>
+          <p class="hide-screen neededDate">\{{neededDate}}</p>
           <p class="hide-screen distanceAwayInMetres">\{{distanceAwayInMetres}}</p>
           <p class="hide-screen keywords">\{{keywords}}</p>
         </div>


### PR DESCRIPTION
Simply changes the posted date to use the neededDate property from the API when displaying needs and sorting by date.

If the API changes to add the neededDate property are not deployed then it will use creationDate as the value to display/sort by.