### PR TITLE
Fix nav bug

### DIFF
--- a/src/scss/partials/_nav.scss
+++ b/src/scss/partials/_nav.scss
@@ -129,6 +129,12 @@ $columned-dropdown-column-count: 3;
   }
 }
 
+body, html { 
+  @include mq($until: m) {
+    overflow-x: hidden;
+  }
+}
+
 .nav {
   @media print {
     & {


### PR DESCRIPTION
according to [this link](https://css-tricks.com/findingfixing-unintended-body-overflow/) `overflow-x: fixed` is an issue in Blink or WebKit based browsers (like Chrome). Not an issue in Gecko based browsers (like Firefox). The solution is to apply `overflow-x: hiddden` to the html and body element.