### PR TITLE
Add suspension notice to Nottingham Street Aid application page

### DIFF
--- a/src/pages/nottingham/street-aid/index.hbs
+++ b/src/pages/nottingham/street-aid/index.hbs
@@ -33,9 +33,12 @@ location: nottingham
       <h2 class="h2">What is Nottingham Street Aid?</h2>
       <p>Nottingham Street Aid is a fund that gives grants to help individuals avoid spending time living on the street.</p>
       <h2 class="h2">How can organisations apply to access the fund?</h2>
-      <p>The Registration and Application process opens on January 2 2024. Full details can be found on <a href="https://nottinghamstreetaid.net">Nottingham Street Aid</a>.</p>
+      <div class="street-aid-suspension-notice">
+        <p><strong>Important:</strong> For technical reasons, the application process for Nottingham Street Aid has been suspended until 2026. It is not yet clear how long this suspension will last. Applications can still be submitted but will not be considered until we are able to reactivate the funding process. We will let applicants know when we are again able to consider applications.</p>
+      </div>
+      <p>Full details can be found on <a href="https://nottinghamstreetaid.net">Nottingham Street Aid</a>.</p>
       <a class="btn btn--brand-d" target="_blank" href="https://nottinghamstreetaid.net">
-        <span class="btn__text">Apply for funds</span>
+        <span class="btn__text">Submit an application</span>
       </a>
       <h2 class="h2">How can the public donate to Nottingham Street Aid?</h2>
       <p>Donations and gift aid from the public will enter the fund through donation contactless points (£3 per donation), Texting STREET plus a number 1-20 to 70560 to donate £1-20 or via our donation web page (reached from a QR code or via this Street Support Nottingham webpage).</p>
@@ -90,7 +93,3 @@ location: nottingham
     <p>We have been able to draw money to the scheme from the council and businesses, much of which would not otherwise have been spent. This money covers all overheads, so that all the money donated by the public (including Gift Aid) is spent on items for homeless people in Nottingham.</p>
   </div>
 </div>
-
-
-
-

--- a/src/scss/partials/_block-ssn.scss
+++ b/src/scss/partials/_block-ssn.scss
@@ -323,7 +323,8 @@
     }
 
     a {
-      color: $brand-f;
+      color: $brand-c;
+      text-decoration: underline;
     }
 
     img {
@@ -1375,4 +1376,21 @@
 .block-footer {
   text-align: center;
   padding: 20px 0;
+}
+
+.street-aid-suspension-notice {
+  background-color: $street-aid-orange;
+  color: $brand-l;
+  padding: 15px 20px;
+  margin: 15px 0;
+  border-radius: 4px;
+
+  p {
+    margin: 0;
+  }
+
+  a {
+    color: $brand-l;
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
- Add notice informing users that applications are suspended until 2026
- Update button text from "Apply for funds" to "Submit an application"
- Improve link colour accessibility on Street Aid homepage banner
- Add styling for suspension notice with accessible colour contrast