### PR TITLE
Remove suspension notice from Nottingham Street Aid page

### DIFF
--- a/src/pages/nottingham/street-aid/index.hbs
+++ b/src/pages/nottingham/street-aid/index.hbs
@@ -33,9 +33,6 @@ location: nottingham
       <h2 class="h2">What is Nottingham Street Aid?</h2>
       <p>Nottingham Street Aid is a fund that gives grants to help individuals avoid spending time living on the street.</p>
       <h2 class="h2">How can organisations apply to access the fund?</h2>
-      <div class="street-aid-suspension-notice">
-        <p><strong>Important:</strong> For technical reasons, the application process for Nottingham Street Aid has been suspended until 2026. It is not yet clear how long this suspension will last. Applications can still be submitted but will not be considered until we are able to reactivate the funding process. We will let applicants know when we are again able to consider applications.</p>
-      </div>
       <p>Full details can be found on <a href="https://nottinghamstreetaid.net">Nottingham Street Aid</a>.</p>
       <a class="btn btn--brand-d" target="_blank" href="https://nottinghamstreetaid.net">
         <span class="btn__text">Submit an application</span>


### PR DESCRIPTION
Remove the temporary suspension notice from the Nottingham Street Aid page now that the application process has resumed.