### PR TITLE
Remove text donation option from Nottingham Street Aid page

### DIFF
--- a/src/pages/nottingham/street-aid/index.hbs
+++ b/src/pages/nottingham/street-aid/index.hbs
@@ -38,7 +38,7 @@ location: nottingham
         <span class="btn__text">Submit an application</span>
       </a>
       <h2 class="h2">How can the public donate to Nottingham Street Aid?</h2>
-      <p>Donations and gift aid from the public will enter the fund through donation contactless points (£3 per donation), Texting STREET plus a number 1-20 to 70560 to donate £1-20 or via our donation web page (reached from a QR code or via this Street Support Nottingham webpage).</p>
+      <p>Donations and gift aid from the public will enter the fund through donation contactless points (£3 per donation) or via our donation web page (reached from a QR code or via this Street Support Nottingham webpage).</p>
       <h2 class="h2">How does Nottingham Street Aid work?</h2>
       <p>Charities that have registered with Nottingham Street Aid can apply to the fund at any time on behalf of an individual to buy a specific item or items that will help them move on from homelessness.</p>
       <p>An independent panel reviews applications and makes grants. Nottingham Street Aid verifies that every penny given is spent on the items requested and evaluates the extent to which the grant achieves its goal of helping that person to move away from life on the streets.</p>


### PR DESCRIPTION
## Summary

Removes the text donation reference from the Nottingham Street Aid page as this option is no longer available.

## Changes

- Removed reference to texting STREET plus a number to 70560 for donations
- Donation options now listed as contactless points and the web donation page only