### PR TITLE
feat: switch analytics cookies from opt-in to opt-out consent model

### DIFF
--- a/src/pages/about/privacy-and-data/cookie-policy/index.hbs
+++ b/src/pages/about/privacy-and-data/cookie-policy/index.hbs
@@ -22,7 +22,7 @@ section: about
 <div class="block block--header">
   <div class="container">
     <h1 class="h1 block__header">Cookie Policy</h1>
-    <p><span class="italic">Effective date: 25/04/2025</span></p>
+    <p><span class="italic">Effective date: 09/02/2026</span></p>
   </div>
 </div>
 
@@ -42,8 +42,9 @@ section: about
         </li>
         <li>
           <h3 class="h3">Analytics Cookies</h3>
-          <p>These cookies help us analyse website traffic and user behaviour, allowing us to improve the performance and functionality of our site. We use Google Analytics and other similar services for this purpose.</p>
-          <p>You can choose to accept or reject these cookies.</p>
+          <p>These cookies help us analyse website traffic and usage patterns in aggregate, allowing us to improve the performance and functionality of our site. We use Google Analytics for this purpose. The data collected is statistical and is not used to identify individual users.</p>
+          <p>Under the UK Data Use and Access Act 2025, analytics cookies used for statistical purposes are permitted without prior consent, provided users are clearly informed and can easily opt out. Accordingly, analytics cookies are enabled by default when you visit our site.</p>
+          <p>You can opt out of analytics cookies at any time through our cookie settings (available via the "Manage Cookies" link in the footer) or through your browser settings.</p>
           <p>Examples:</p>
           <ul>
             <li>Google Analytics</li>
@@ -71,8 +72,8 @@ section: about
         </li>
       </ol>
       <h2 class="h2">Managing Your Cookie Preferences</h2>
-      <p>You can control your cookie preferences through our cookie banner or through your browser settings. The cookie banner will appear when you first visit our site, giving you the option to accept or reject non-essential cookies.</p>
-      <p>If you wish to adjust your preferences at any time, you can do so by clicking the "Cookie Settings" link in the footer of our website or through your browser settings.</p>
+      <p>When you first visit our site, a cookie banner will inform you about our use of cookies. Analytics cookies are enabled by default (opt-out). Marketing cookies are disabled by default and require your consent (opt-in).</p>
+      <p>You can change your preferences at any time by clicking the "Manage Cookies" link in the footer of our website. You can also control cookies through your browser settings.</p>
       <h2 class="h2">How to Control Cookies in Your Browser</h2>
       <p>Most web browsers allow you to control cookies through their settings. You can set your browser to block all cookies or to alert you when cookies are being sent. However, please note that blocking all cookies may affect the functionality of our website.</p>
       <p>For more information on how to manage cookies, you can visit the following links based on your browser:</p>

--- a/src/partials/foot-with-google-maps.hbs
+++ b/src/partials/foot-with-google-maps.hbs
@@ -7,7 +7,7 @@
   <div class="cookie-banner__content">
     <h2 id="cookie-banner-title" class="cookie-banner__title">Cookie Preferences</h2>
     <p class="cookie-banner__text">
-      We use cookies to keep the site working and, with your permission, to analyse how it's used so we can improve it.
+      We use essential cookies to keep the site working. We also use analytics cookies to understand how the site is used so we can improve it. Analytics cookies are enabled by default and you can opt out at any time.
     </p>
     <p class="cookie-banner__policy-link">
       <a href="/about/privacy-and-data/cookie-policy" target="_blank" rel="noopener">Read our Cookie Policy</a>
@@ -16,6 +16,7 @@
       <button id="accept-all" class="cookie-banner__button cookie-banner__button--primary">Accept All</button>
       <button id="reject-all" class="cookie-banner__button cookie-banner__button--secondary">Essential Only</button>
       <button id="cookie-settings-btn" class="cookie-banner__button cookie-banner__button--tertiary">Cookie Settings</button>
+      <button id="dismiss-banner" class="cookie-banner__button cookie-banner__button--tertiary">Dismiss</button>
     </div>
   </div>
 </div>
@@ -29,7 +30,7 @@
       <button id="close-modal-x" class="cookie-settings-modal__close" aria-label="Close cookie settings">&times;</button>
     </div>
     <p class="cookie-settings-modal__description">
-      Choose which optional cookies you'd like to allow. Essential cookies are always active to keep the site working.
+      Analytics cookies are enabled by default for statistical purposes under the UK Data Use and Access Act 2025. You can opt out below. Marketing cookies require your consent and are off by default.
     </p>
     <form id="cookie-settings-form" class="cookie-settings-form">
       <div class="cookie-settings-form__group">
@@ -135,7 +136,7 @@
       var prefs = getStoredPreferences();
 
       // Set checkbox states based on stored preferences
-      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : false;
+      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : true;
       settingsForm.querySelector('input[name="advertisement"]').checked = prefs ? prefs.advertisement : false;
 
       modalBackdrop.classList.add("cookie-modal-backdrop--visible");
@@ -194,6 +195,12 @@
       hideBanner();
     }
 
+    function handleDismiss() {
+      var prefs = { analytics: true, advertisement: false };
+      savePreferences(prefs);
+      hideBanner();
+    }
+
     function handleSaveSettings() {
       var prefs = {
         analytics: settingsForm.querySelector('input[name="analytics"]').checked,
@@ -224,6 +231,7 @@
       document.getElementById("accept-all").addEventListener("click", handleAcceptAll);
       document.getElementById("reject-all").addEventListener("click", handleRejectAll);
       document.getElementById("cookie-settings-btn").addEventListener("click", openModal);
+      document.getElementById("dismiss-banner").addEventListener("click", handleDismiss);
       document.getElementById("close-modal-x").addEventListener("click", closeModal);
       document.getElementById("close-settings").addEventListener("click", closeModal);
       document.getElementById("save-settings").addEventListener("click", handleSaveSettings);

--- a/src/partials/foot-with-va.hbs
+++ b/src/partials/foot-with-va.hbs
@@ -7,7 +7,7 @@
   <div class="cookie-banner__content">
     <h2 id="cookie-banner-title" class="cookie-banner__title">Cookie Preferences</h2>
     <p class="cookie-banner__text">
-      We use cookies to keep the site working and, with your permission, to analyse how it's used so we can improve it.
+      We use essential cookies to keep the site working. We also use analytics cookies to understand how the site is used so we can improve it. Analytics cookies are enabled by default and you can opt out at any time.
     </p>
     <p class="cookie-banner__policy-link">
       <a href="/about/privacy-and-data/cookie-policy" target="_blank" rel="noopener">Read our Cookie Policy</a>
@@ -16,6 +16,7 @@
       <button id="accept-all" class="cookie-banner__button cookie-banner__button--primary">Accept All</button>
       <button id="reject-all" class="cookie-banner__button cookie-banner__button--secondary">Essential Only</button>
       <button id="cookie-settings-btn" class="cookie-banner__button cookie-banner__button--tertiary">Cookie Settings</button>
+      <button id="dismiss-banner" class="cookie-banner__button cookie-banner__button--tertiary">Dismiss</button>
     </div>
   </div>
 </div>
@@ -29,7 +30,7 @@
       <button id="close-modal-x" class="cookie-settings-modal__close" aria-label="Close cookie settings">&times;</button>
     </div>
     <p class="cookie-settings-modal__description">
-      Choose which optional cookies you'd like to allow. Essential cookies are always active to keep the site working.
+      Analytics cookies are enabled by default for statistical purposes under the UK Data Use and Access Act 2025. You can opt out below. Marketing cookies require your consent and are off by default.
     </p>
     <form id="cookie-settings-form" class="cookie-settings-form">
       <div class="cookie-settings-form__group">
@@ -135,7 +136,7 @@
       var prefs = getStoredPreferences();
 
       // Set checkbox states based on stored preferences
-      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : false;
+      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : true;
       settingsForm.querySelector('input[name="advertisement"]').checked = prefs ? prefs.advertisement : false;
 
       modalBackdrop.classList.add("cookie-modal-backdrop--visible");
@@ -194,6 +195,12 @@
       hideBanner();
     }
 
+    function handleDismiss() {
+      var prefs = { analytics: true, advertisement: false };
+      savePreferences(prefs);
+      hideBanner();
+    }
+
     function handleSaveSettings() {
       var prefs = {
         analytics: settingsForm.querySelector('input[name="analytics"]').checked,
@@ -224,6 +231,7 @@
       document.getElementById("accept-all").addEventListener("click", handleAcceptAll);
       document.getElementById("reject-all").addEventListener("click", handleRejectAll);
       document.getElementById("cookie-settings-btn").addEventListener("click", openModal);
+      document.getElementById("dismiss-banner").addEventListener("click", handleDismiss);
       document.getElementById("close-modal-x").addEventListener("click", closeModal);
       document.getElementById("close-settings").addEventListener("click", closeModal);
       document.getElementById("save-settings").addEventListener("click", handleSaveSettings);

--- a/src/partials/foot.hbs
+++ b/src/partials/foot.hbs
@@ -6,7 +6,7 @@
   <div class="cookie-banner__content">
     <h2 id="cookie-banner-title" class="cookie-banner__title">Cookie Preferences</h2>
     <p class="cookie-banner__text">
-      We use cookies to keep the site working and, with your permission, to analyse how it's used so we can improve it.
+      We use essential cookies to keep the site working. We also use analytics cookies to understand how the site is used so we can improve it. Analytics cookies are enabled by default and you can opt out at any time.
     </p>
     <p class="cookie-banner__policy-link">
       <a href="/about/privacy-and-data/cookie-policy" target="_blank" rel="noopener">Read our Cookie Policy</a>
@@ -15,6 +15,7 @@
       <button id="accept-all" class="cookie-banner__button cookie-banner__button--primary">Accept All</button>
       <button id="reject-all" class="cookie-banner__button cookie-banner__button--secondary">Essential Only</button>
       <button id="cookie-settings-btn" class="cookie-banner__button cookie-banner__button--tertiary">Cookie Settings</button>
+      <button id="dismiss-banner" class="cookie-banner__button cookie-banner__button--tertiary">Dismiss</button>
     </div>
   </div>
 </div>
@@ -28,7 +29,7 @@
       <button id="close-modal-x" class="cookie-settings-modal__close" aria-label="Close cookie settings">&times;</button>
     </div>
     <p class="cookie-settings-modal__description">
-      Choose which optional cookies you'd like to allow. Essential cookies are always active to keep the site working.
+      Analytics cookies are enabled by default for statistical purposes under the UK Data Use and Access Act 2025. You can opt out below. Marketing cookies require your consent and are off by default.
     </p>
     <form id="cookie-settings-form" class="cookie-settings-form">
       <div class="cookie-settings-form__group">
@@ -134,7 +135,7 @@
       var prefs = getStoredPreferences();
 
       // Set checkbox states based on stored preferences
-      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : false;
+      settingsForm.querySelector('input[name="analytics"]').checked = prefs ? prefs.analytics : true;
       settingsForm.querySelector('input[name="advertisement"]').checked = prefs ? prefs.advertisement : false;
 
       modalBackdrop.classList.add("cookie-modal-backdrop--visible");
@@ -193,6 +194,12 @@
       hideBanner();
     }
 
+    function handleDismiss() {
+      var prefs = { analytics: true, advertisement: false };
+      savePreferences(prefs);
+      hideBanner();
+    }
+
     function handleSaveSettings() {
       var prefs = {
         analytics: settingsForm.querySelector('input[name="analytics"]').checked,
@@ -223,6 +230,7 @@
       document.getElementById("accept-all").addEventListener("click", handleAcceptAll);
       document.getElementById("reject-all").addEventListener("click", handleRejectAll);
       document.getElementById("cookie-settings-btn").addEventListener("click", openModal);
+      document.getElementById("dismiss-banner").addEventListener("click", handleDismiss);
       document.getElementById("close-modal-x").addEventListener("click", closeModal);
       document.getElementById("close-settings").addEventListener("click", closeModal);
       document.getElementById("save-settings").addEventListener("click", handleSaveSettings);

--- a/src/partials/head--alpaca.hbs
+++ b/src/partials/head--alpaca.hbs
@@ -14,12 +14,17 @@
 
     <link rel="stylesheet" href="{{site.url}}assets/css/site.css?v={{site.cssVersion}}" />
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <!-- Google Tag Manager - gated by cookie consent (opt-out model) -->
+    <script>(function(){
+    var stored=localStorage.getItem("cookieConsent");
+    var allowed=true;
+    if(stored){try{var p=JSON.parse(stored);allowed=p.analytics!==false;}catch(e){}}
+    if(allowed){(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-PVPXCXT');</script>
+    })(window,document,'script','dataLayer','GTM-PVPXCXT');}
+    })();</script>
     <!-- End Google Tag Manager -->
 
     <script>

--- a/src/partials/head/google-tag-manager.hbs
+++ b/src/partials/head/google-tag-manager.hbs
@@ -1,9 +1,23 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-NQP6KG1Q11"></script>
+<!-- Google tag (gtag.js) - gated by cookie consent (opt-out model) -->
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-NQP6KG1Q11');
+  (function() {
+    var stored = localStorage.getItem("cookieConsent");
+    var analyticsAllowed = true;
+    if (stored) {
+      try {
+        var prefs = JSON.parse(stored);
+        analyticsAllowed = prefs.analytics !== false;
+      } catch (e) {}
+    }
+    if (analyticsAllowed) {
+      var s = document.createElement('script');
+      s.async = true;
+      s.src = 'https://www.googletagmanager.com/gtag/js?id=G-NQP6KG1Q11';
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-NQP6KG1Q11');
+    }
+  })();
 </script>

--- a/src/partials/notts-footer.hbs
+++ b/src/partials/notts-footer.hbs
@@ -23,7 +23,8 @@
       <div>
         <p><a href="https://beta.companieshouse.gov.uk/company/10348840">Street Support Network Ltd</a> is a <a href="http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1177546&SubsidiaryNumber=0">Registered Charity: 1177546</a></p>
         <p class="footer__copy">&copy; 2024 Street Support Network
-          <a class="footer__link" href="/privacy-policy">Privacy Policy</a>
+          <a class="footer__link" href="/about/privacy-and-data/privacy-policy/">Privacy Policy</a>
+          <a class="footer__link" href="#" onclick="openCookieSettings(); return false;">Manage Cookies</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Switches analytics cookies from opt-in to opt-out under the UK Data Use and Access Act 2025 statistical purposes exception. GA/GTM now loads conditionally based on stored consent preferences, fixing the existing gap where they loaded unconditionally regardless of user choice.

## Changes

- Gate GA script loading behind localStorage consent check in google-tag-manager.hbs (opt-out default: allowed unless explicitly opted out)
- Gate GTM snippet behind the same consent check in head--alpaca.hbs
- Update banner text in all three foot partials to reflect opt-out model
- Update modal description to cite the UK Data Use and Access Act 2025
- Default analytics checkbox to checked when no stored preferences
- Add Dismiss button to cookie banner (stores analytics: true, advertisement: false)
- Update cookie policy page with new effective date, legal basis, and opt-out instructions
- Add Manage Cookies link to Nottingham footer and fix privacy policy URL

## Testing

- Clear localStorage, visit site: banner appears, GA loads (check Network tab), analytics checkbox is checked in settings
- Click Dismiss: stores default preferences, banner hides
- Click Essential Only or uncheck analytics in settings, reload: GA does not load
- Click Manage Cookies in footer, re-enable analytics, reload: GA loads
- Set cookieConsent to {"analytics":false,"advertisement":false} in localStorage, reload: GA blocked, banner hidden
- Verify Nottingham layout has Manage Cookies link that opens settings modal
- Verify alpaca layout pages gate GTM loading correctly