### PR TITLE
feat: add site-wide banner and page for new website launch

### DIFF
--- a/src/layouts/alpaca.hbs
+++ b/src/layouts/alpaca.hbs
@@ -15,7 +15,8 @@
     </ul>
   </nav>
 
-  {{{ contents }}} 
+  {{> new-site-banner }}
+  {{{ contents }}}
   {{> footer }}
 
   <div class="nav__overlay js-nav-overlay"></div>

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -15,7 +15,8 @@
     </ul>
   </nav>
 
-  {{{ contents }}} 
+  {{> new-site-banner }}
+  {{{ contents }}}
   {{> footer }}
 
   <div class="nav__overlay js-nav-overlay"></div>

--- a/src/layouts/nottingham.hbs
+++ b/src/layouts/nottingham.hbs
@@ -15,6 +15,7 @@
     </ul>
   </nav>
 
+  {{> new-site-banner }}
   {{{ contents }}}
   {{> notts-footer }}
 

--- a/src/layouts/withGiveHelp.hbs
+++ b/src/layouts/withGiveHelp.hbs
@@ -15,6 +15,7 @@
     </ul>
   </nav>
 
+  {{> new-site-banner }}
   {{{ contents }}}
   {{> footer }}
 

--- a/src/layouts/withGoogle.hbs
+++ b/src/layouts/withGoogle.hbs
@@ -15,7 +15,8 @@
     </ul>
   </nav>
 
-  {{{ contents }}} 
+  {{> new-site-banner }}
+  {{{ contents }}}
   {{> footer }}
 
   <div class="nav__overlay js-nav-overlay"></div>

--- a/src/layouts/withVa.hbs
+++ b/src/layouts/withVa.hbs
@@ -15,6 +15,7 @@
     </ul>
   </nav>
 
+  {{> new-site-banner }}
   {{{ contents }}}
   {{> footer }}
 

--- a/src/pages/about/new-website/index.hbs
+++ b/src/pages/about/new-website/index.hbs
@@ -1,0 +1,88 @@
+---
+title: New Website Launching 23 March 2026 - Street Support
+description: Street Support Network is launching an improved website on 23 March 2026 with a better find help experience and a more intuitive admin system.
+image: https://streetsupport.net/assets/img/og/street-support.jpg
+layout: default.hbs
+permalink: false
+jsBundle: generic
+section: about
+page: about
+---
+
+<div class="block block--breadcrumbs">
+  <div class="container">
+    <ol class="breadcrumbs__list">
+      <li class="breadcrumbs__item">
+        <a href="/">Home</a>
+      </li>
+      <li class="breadcrumbs__item">
+        <a href="/about">About</a>
+      </li>
+      <li class="breadcrumbs__item">New Website</li>
+    </ol>
+  </div>
+</div>
+
+<div class="block block--header">
+  <div class="container">
+    <h1 class="h1 block__header">A New Street Support Website</h1>
+    <h2 class="h2 block__sub-header">Launching 23 March 2026</h2>
+  </div>
+</div>
+
+<div class="block">
+  <div class="container">
+    <div class="block__content">
+      <p>We've been working hard to make significant improvements to Street Support Network, and we're excited to share what's coming.</p>
+    </div>
+
+    <div class="block__section">
+      <h2 class="h2">A better Find Help experience</h2>
+      <p>The way people search for support services is getting a major upgrade. You'll be able to find help using your current location, a postcode, or by browsing predefined areas &mdash; whichever works best for you.</p>
+      <p>Search results will now show services on an interactive map alongside listings, making it easier to see what's nearby. Results are sorted by distance, so the most relevant services appear first.</p>
+      <p>The new site is faster and more accessible, built to work well on all devices and meet modern accessibility standards.</p>
+    </div>
+
+    <div class="block__section">
+      <h2 class="h2">What this means for people seeking help</h2>
+      <ul>
+        <li>Multiple ways to search: use your location, enter a postcode, or select an area</li>
+        <li>See services on a map with distance information</li>
+        <li>Faster page loads and a clearer layout</li>
+        <li>Better experience on mobile phones and tablets</li>
+      </ul>
+    </div>
+
+    {{> divider }}
+
+    <div class="block__section">
+      <h2 class="h2">For administrators and organisations</h2>
+      <p>Alongside the new public website, we're also launching an updated admin system that is more intuitive and easier to use.</p>
+    </div>
+
+    <div class="block__section">
+      <h3 class="h3">Your login details will not change</h3>
+      <p>You will use the same login credentials you use today. There is no need to create a new account or reset your password. The login process remains the same.</p>
+    </div>
+
+    <div class="block__section">
+      <h3 class="h3">User guides</h3>
+      <p>New user guides will be available to download from Monday 24 March, after you log in to the new admin system. These guides will walk you through the updated interface and help you get familiar with the changes.</p>
+    </div>
+
+    <div class="block__section">
+      <h3 class="h3">What's different in the admin system</h3>
+      <ul>
+        <li>A clearer, more modern interface that's easier to navigate</li>
+        <li>Better organised menus and workflows</li>
+        <li>Helpful notifications so you know when actions have been saved</li>
+        <li>A rich text editor for content, replacing plain text fields</li>
+        <li>Breadcrumb navigation so you always know where you are</li>
+      </ul>
+    </div>
+
+    <div class="block__content">
+      <p>If you have any questions or need support during the transition, please <a href="/about/contact">get in touch</a>.</p>
+    </div>
+  </div>
+</div>

--- a/src/partials/new-site-banner.hbs
+++ b/src/partials/new-site-banner.hbs
@@ -1,0 +1,5 @@
+<div class="new-site-banner">
+  <div class="container">
+    <p class="new-site-banner__text">We're launching a new website on 23 March 2026. <a href="/about/new-website" class="new-site-banner__link">Learn more</a></p>
+  </div>
+</div>

--- a/src/partials/new-site-banner.hbs
+++ b/src/partials/new-site-banner.hbs
@@ -1,5 +1,6 @@
 <div class="new-site-banner">
   <div class="container">
     <p class="new-site-banner__text">We're launching a new website on 23 March 2026. <a href="/about/new-website" class="new-site-banner__link">Learn more</a></p>
+    <p class="new-site-banner__text new-site-banner__text--notice">Important: There may be some downtime or service disruption between 9pm on Sunday 22nd and 1am on Monday 23rd March. After then, all services should be fully operational.</p>
   </div>
 </div>

--- a/src/scss/partials/_new-site-banner.scss
+++ b/src/scss/partials/_new-site-banner.scss
@@ -1,0 +1,25 @@
+.new-site-banner {
+  background: $brand-k;
+  padding: 10px 0;
+  text-align: center;
+  margin-top: -5px;
+
+  + .block--breadcrumbs {
+    margin-top: 0;
+  }
+}
+
+.new-site-banner__text {
+  color: #fff;
+  font-size: 15px;
+  margin: 0;
+}
+
+.new-site-banner__link {
+  color: $brand-e;
+  text-decoration: underline;
+
+  &:hover {
+    color: $brand-d;
+  }
+}

--- a/src/scss/partials/_new-site-banner.scss
+++ b/src/scss/partials/_new-site-banner.scss
@@ -13,6 +13,11 @@
   color: #fff;
   font-size: 15px;
   margin: 0;
+
+  &--notice {
+    margin-top: 5px;
+    font-size: 13px;
+  }
 }
 
 .new-site-banner__link {

--- a/src/scss/site.scss
+++ b/src/scss/site.scss
@@ -82,6 +82,7 @@
 @import 'partials/postcode-multi-button';
 @import 'partials/search-advice';
 @import 'partials/support-section';
+@import 'partials/new-site-banner';
 
 // Utilities
 @import 'partials/utilities';


### PR DESCRIPTION
## Summary

Adds an announcement banner across all pages and a dedicated information page at `/about/new-website` for the new website launching 23 March 2026.

## Changes

- Added `new-site-banner` partial rendered in all 6 layout files (default, withGoogle, withGiveHelp, withVa, nottingham, alpaca)
- Banner displays between the nav and page content with a text link to the learn more page
- Created `/about/new-website/index.hbs` page covering:
  - Find Help journey improvements (geolocation, postcode search, interactive map, distance sorting)
  - Reassurance for administrators that login credentials will not change
  - User guides available from Monday 24 March after logging in to the new admin system
  - Summary of admin system interface changes
- Added `_new-site-banner.scss` with styling and breadcrumb overlap fix

## Testing

- Run `npx gulp` and verify the banner appears on all pages
- Navigate to `/about/new-website` and check content renders correctly
- Verify breadcrumbs are not overlapped by the banner on inner pages
- Check banner displays correctly on mobile viewports